### PR TITLE
Add passing instance argument on callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function useBrowserLauncher(url, cfg, cb) {
                     instance.stderr.unref();
                     instance.process.unref();
                 }
-                cb(null, 'Started ' + command + ' successfully');
+                cb(null, 'Started ' + command + ' successfully', instance);
             });
         });
 


### PR DESCRIPTION
It is necessary to control the running process
